### PR TITLE
Modernize UI styles

### DIFF
--- a/components/common/Button.tsx
+++ b/components/common/Button.tsx
@@ -15,13 +15,13 @@ export const Button: React.FC<ButtonProps> = ({
   className = '',
   ...props
 }) => {
-  const baseStyles = "font-medium rounded-lg focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors duration-150 ease-in-out disabled:opacity-50 disabled:cursor-not-allowed";
+  const baseStyles = "font-medium rounded-full focus:outline-none focus:ring-2 focus:ring-offset-2 transition-all duration-200 ease-in-out hover:-translate-y-0.5 hover:shadow-md disabled:opacity-50 disabled:cursor-not-allowed";
   
   const variantStyles = {
-    primary: 'bg-teal-600 hover:bg-teal-700 text-white focus:ring-teal-500',
-    secondary: 'bg-slate-200 hover:bg-slate-300 text-slate-700 focus:ring-slate-400',
-    danger: 'bg-red-500 hover:bg-red-600 text-white focus:ring-red-400',
-    ghost: 'bg-transparent hover:bg-teal-100 text-teal-600 focus:ring-teal-500 border border-teal-600',
+    primary: 'bg-teal-400 hover:bg-teal-500 text-teal-900 focus:ring-teal-300',
+    secondary: 'bg-slate-100 hover:bg-slate-200 text-slate-700 focus:ring-slate-300',
+    danger: 'bg-red-400 hover:bg-red-500 text-white focus:ring-red-300',
+    ghost: 'bg-transparent hover:bg-teal-100 text-teal-600 focus:ring-teal-300 border border-teal-400',
   };
 
   const sizeStyles = {

--- a/components/common/Input.tsx
+++ b/components/common/Input.tsx
@@ -11,7 +11,7 @@ export const Input: React.FC<InputProps> = ({ label, id, error, className, ...pr
       {label && <label htmlFor={id} className="block text-sm font-medium text-slate-700 mb-1">{label}</label>}
       <input
         id={id}
-        className={`block w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm placeholder-slate-400 focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm ${className} ${error ? 'border-red-500' : ''}`}
+        className={`block w-full px-3 py-2 border border-slate-200 rounded-lg shadow-sm placeholder-slate-400 focus:outline-none focus:ring-teal-300 focus:border-teal-300 sm:text-sm font-light ${className} ${error ? 'border-red-300' : ''}`}
         {...props}
       />
       {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
@@ -30,7 +30,7 @@ export const Textarea: React.FC<TextareaProps> = ({ label, id, error, className,
       {label && <label htmlFor={id} className="block text-sm font-medium text-slate-700 mb-1">{label}</label>}
       <textarea
         id={id}
-        className={`block w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm placeholder-slate-400 focus:outline-none focus:ring-teal-500 focus:border-teal-500 sm:text-sm ${className} ${error ? 'border-red-500' : ''}`}
+        className={`block w-full px-3 py-2 border border-slate-200 rounded-lg shadow-sm placeholder-slate-400 focus:outline-none focus:ring-teal-300 focus:border-teal-300 sm:text-sm font-light ${className} ${error ? 'border-red-300' : ''}`}
         {...props}
       />
       {error && <p className="mt-1 text-xs text-red-600">{error}</p>}

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -12,8 +12,8 @@ export const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, 
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-sm p-4">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-md max-h-[90vh] flex flex-col">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 backdrop-blur-md p-4">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] flex flex-col">
         <div className="flex items-center justify-between p-4 border-b border-slate-200">
           <h3 className="text-xl font-semibold text-slate-700">{title}</h3>
           <button

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -10,17 +10,16 @@ export const Header: React.FC = () => {
 
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>
     `px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-      isActive ? 'bg-teal-700 text-white' : 'text-emerald-100 hover:bg-teal-600 hover:text-white'
+      isActive ? 'bg-teal-500 text-white' : 'text-teal-700 hover:bg-teal-100 hover:text-teal-900'
     }`;
 
   return (
-    <header className="bg-teal-600 shadow-md">
+    <header className="bg-gradient-to-r from-emerald-50 via-emerald-100 to-emerald-50 shadow-sm">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           <div className="flex items-center">
-            <NavLink to="/" className="text-2xl font-bold text-white">
-              {APP_NAME}
-            </NavLink>
+            <NavLink to="/" className="text-3xl font-extrabold text-teal-700">Hanami</NavLink>
+            <span className="ml-2 text-sm text-teal-500 hidden sm:inline">{APP_NAME}</span>
           </div>
           <nav className="flex items-center space-x-4">
             {currentUser ? (
@@ -43,8 +42,8 @@ export const Header: React.FC = () => {
                     <NavLink to="/dashboard/admin/classes" className={navLinkClass}>Tous les cours</NavLink>
                    </>
                 )}
-                <span className="text-emerald-100 text-sm hidden md:block">Bonjour, {currentUser.name} ({currentUser.role})</span>
-                <Button onClick={logout} variant="ghost" size="sm" className="border-emerald-100 text-emerald-100 hover:bg-white hover:text-teal-600">
+                <span className="text-teal-600 text-sm hidden md:block">Bonjour, {currentUser.name} ({currentUser.role})</span>
+                <Button onClick={logout} variant="ghost" size="sm" className="border-teal-600 text-teal-600 hover:bg-white hover:text-teal-700">
                   Déconnexion
                 </Button>
               </>


### PR DESCRIPTION
## Summary
- add modern pastel styles to the Button component
- use softer borders and fonts for Input fields
- blur modal backdrop and smooth corners
- update header design with Hanami branding and gradient background

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68407cbe83ac8322a567943d01add178