### PR TITLE
Add Vitest config and utilities tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Run Tests
+
+Execute unit tests with:
+
+```
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -16,6 +17,7 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "typescript": "~5.7.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^1.4.0"
   }
 }

--- a/tests/dateUtils.test.ts
+++ b/tests/dateUtils.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getUpcomingClassDates, isCancellationAllowed, getWeekNumber } from '../utils/dateUtils';
+import { YogaClass } from '../types';
+
+describe('dateUtils', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('getUpcomingClassDates retourne les dates tri\u00e9es et limit\u00e9es', () => {
+    const baseDate = new Date('2023-09-04T10:00:00Z'); // Monday
+    vi.setSystemTime(baseDate);
+    const yogaClass: YogaClass = {
+      id: '1',
+      name: 'Test',
+      teacherId: 't1',
+      teacherName: 'Teacher',
+      dayOfWeek: 'Mercredi',
+      startTime: '10:00',
+      endTime: '11:00',
+      location: 'Studio',
+      totalSlots: 10,
+      cancellationWindowHours: 2,
+    };
+    const results = getUpcomingClassDates(yogaClass, 10);
+    const expectedDates = [
+      '2023-09-06',
+      '2023-09-13',
+      '2023-09-20',
+      '2023-09-27',
+      '2023-10-04',
+    ];
+    expect(results.length).toBe(5);
+    expect(results.map(r => r.date)).toEqual(expectedDates);
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].classDateTime.getTime()).toBeGreaterThan(results[i-1].classDateTime.getTime());
+    }
+  });
+
+  it('isCancellationAllowed retourne true ou false selon la fen\u00eatre d\u2019annulation', () => {
+    const classDate = new Date('2023-09-06T10:00:00Z');
+    vi.setSystemTime(new Date('2023-09-06T07:00:00Z'));
+    expect(isCancellationAllowed(classDate, 2)).toBe(true);
+    vi.setSystemTime(new Date('2023-09-06T09:00:00Z'));
+    expect(isCancellationAllowed(classDate, 2)).toBe(false);
+  });
+
+  it('getWeekNumber produit la bonne semaine', () => {
+    expect(getWeekNumber(new Date('2023-06-15'))).toBe(24);
+    expect(getWeekNumber(new Date('2023-12-31'))).toBe(52);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- introduce Vitest and testing scripts
- write unit tests for date utilities
- add Vitest configuration
- document how to run tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684086c4aa94832286caae71ab5e76dd