### PR TITLE
Add filter UI for student classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Filtres pour les élèves
+
+Dans le tableau de bord étudiant, des champs de filtre vous permettent d'affiner la liste des cours par jour, enseignant ou lieu. Laissez un champ vide pour ne pas appliquer ce critère.


### PR DESCRIPTION
## Summary
- enable filtering of available classes on the student dashboard by day, teacher or location
- keep responsive grid layout for new controls
- update README with instructions on the new filters

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684086b7a59483229d0e742b5cd662be